### PR TITLE
Escaped string indicators for .Rprofile

### DIFF
--- a/template/.devcontainer/Dockerfile.jinja
+++ b/template/.devcontainer/Dockerfile.jinja
@@ -49,7 +49,7 @@ RUN apt-get update && \
 RUN R -e "dotR <- file.path(Sys.getenv('HOME'), '.R'); if(!file.exists(dotR)){ dir.create(dotR) }; Makevars <- file.path(dotR, 'Makevars'); if (!file.exists(Makevars)){  file.create(Makevars) }; cat('\nCXX14FLAGS=-O3 -fPIC -Wno-unused-variable -Wno-unused-function', 'CXX14 = g++ -std=c++1y -fPIC', 'CXX = g++', 'CXX11 = g++', file = Makevars, sep = '\n', append = TRUE)"
 
 ### CRAN mirror
-RUN R -e "dotRprofile <- file.path(Sys.getenv('HOME'), '.Rprofile'); if(!file.exists(dotRprofile)){ file.create(dotRprofile) }; cat('local({r <- getOption("repos")', 'r["CRAN"] <- "https://cloud.r-project.org"', 'options(repos=r)', '})', file = dotRprofile, sep = '\n', append = TRUE)"
+RUN R -e "dotRprofile <- file.path(Sys.getenv('HOME'), '.Rprofile'); if(!file.exists(dotRprofile)){ file.create(dotRprofile) }; cat('local({r <- getOption(\"repos\")', 'r[\"CRAN\"] <- \"https://cloud.r-project.org\"', 'options(repos=r)', '})', file = dotRprofile, sep = '\n', append = TRUE)"
 {%- endif %}
 {% if use_quarto %}
 ### Quarto


### PR DESCRIPTION
Strings inside inline R executable script needed to be escaped in order not to cause a syntax error.