### PR TITLE
Removed versioning for system packages

### DIFF
--- a/template/.devcontainer/Dockerfile.jinja
+++ b/template/.devcontainer/Dockerfile.jinja
@@ -26,11 +26,11 @@ USER root
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         # Basic system usage
-        lmodern=2.004.5-6.1 \
-        file=1:5.41-3ubuntu0.1 \
-        curl=7.81.0-1ubuntu1.15 \
-        g++=4:11.2.0-1ubuntu1 \
-        tmux=3.2a-4ubuntu0.2 \
+        lmodern \
+        file \
+        curl \
+        g++ \
+        tmux \
         {%- if use_rstudio %}
         # Dependencies for RStudio
         psmisc \
@@ -38,7 +38,7 @@ RUN apt-get update && \
         libssl-dev \
         libclang-dev \
         libpq5 \
-        libtiff-dev
+        libtiff-dev \
         {%- endif %}
         ###################################################
         ### Add your own system dependencies installed  ###

--- a/template/.devcontainer/Dockerfile.jinja
+++ b/template/.devcontainer/Dockerfile.jinja
@@ -33,12 +33,12 @@ RUN apt-get update && \
         tmux=3.2a-4ubuntu0.2 \
         {%- if use_rstudio %}
         # Dependencies for RStudio
-        psmisc=23.4-2build3 \
-        lsb-release=11.1.0ubuntu4 \
+        psmisc \
+        lsb-release \
         libssl-dev \
-        libclang-dev=1:14.0-55~exp2 \
-        libpq5=14.10-0ubuntu0.22.04.1 \
-        libtiff-dev=4.3.0-6ubuntu0.7 \
+        libclang-dev \
+        libpq5 \
+        libtiff-dev
         {%- endif %}
         ###################################################
         ### Add your own system dependencies installed  ###
@@ -118,8 +118,8 @@ RUN pip install \
     # Versioned
 RUN R -q -e 'remotes::install_version("markdown", version="1.12", repos="cloud.r-project.org")' && \
     R -q -e 'remotes::install_version("languageserver", version="0.3.16", repos="cloud.r-project.org")' && \
+    R -q -e 'remotes::install_version("httpgd", version="2.0.1", repos="cloud.r-project.org")' && \
     # Latest Dev Versions
-    R -q -e 'remotes::install_github("nx10/httpgd")' && \
     R -q -e 'remotes::install_github("ManuelHentschel/vscDebugger")' && \
     ##########################################################
     ### Add your own R dependencies installed as needed    ###

--- a/template/.devcontainer/Dockerfile.jinja
+++ b/template/.devcontainer/Dockerfile.jinja
@@ -1,9 +1,9 @@
 {%- if dev_language == 'R and Python' %}
-FROM docker.io/jupyter/datascience-notebook:r-4.3.1
+FROM quay.io/jupyter/datascience-notebook:r-4.3.1
 {%- elif dev_language == 'Python' %}
-FROM docker.io/jupyter/scipy-notebook:python-3.11.6
+FROM quay.io/jupyter/scipy-notebook:python-3.11.6
 {%- elif dev_language == 'R' %}
-FROM docker.io/jupyter/r-notebook:r-4.3.1
+FROM quay.io/jupyter/r-notebook:r-4.3.1
 {%- endif %}
 
 ### Environment variables


### PR DESCRIPTION
Versioning in system packages caused build failures due to missingness in Ubuntu repositories. Currently, can't support specific versions until we come up with a better solution, with more consistent behavior.